### PR TITLE
buildscript translation support re-add

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -128,9 +128,11 @@ function generate_static_html {
         done
     done	
 
-	mv build/output/homepage/* build/output
+    sphinx-build -M html build/input/homepage build/output/homepage
 
-	rmdir build/output/homepage
+    mv build/output/homepage/html/* build/output/
+
+    rm -r build/output/homepage
 }
 
 function main {

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -64,14 +64,17 @@ function generate_static_html {
             for language in `find build/input/${product_name}/${version_name} -maxdepth 1 -mindepth 1 -type d -printf "%f\n"`; do
                 echo "Generating static html for $product_name $version_name $language"
 
+                input_path="build/input/${product_name}/${version_name}/${language}"
+                output_path="build/output/${product_name}/${version_name}/${language}"
+
                 #
                 # Use Sphinx to generate static HTML for each
                 #   product/version/language. The Homepage content is built
                 #   separately at the end of the function.
                 #
-                sphinx-build -M html build/input/${product_name}/${version_name}/${language} build/output/${product_name}/${version_name}/${language}
+                sphinx-build -M html ${input_path} ${output_path}
 
-                mv build/output/${product_name}/${version_name}/${language}/html/* build/output/${product_name}/${version_name}/${language}
+                mv ${output_path}/html/* ${output_path}
 
 		#
 		# Fix broken links.

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -33,21 +33,22 @@ function generate_sphinx_input {
 		then
 			continue
 		fi
-
 		for version_name in `find ../docs/${product_name} -maxdepth 1 -mindepth 1 -printf "%f\n" -type d`
 		do
-			mkdir -p build/input/${product_name}-${version_name}/docs
+            for language in `find ../docs/${product_name}/${version_name} -maxdepth 1 -mindepth 1 -type d -printf "%f\n"`
+            do
+                if [ ! -f "../docs/${product_name}/${version_name}/${language}/contents.rst" ]; then
+                    echo "docs/${product_name}/${version_name}/${language}/contents.rst does not exist, skipping..."
+                else
+                    mkdir -p build/input/${product_name}/${version_name}/${language}/docs
 
-			cp -R docs/* build/input/${product_name}-${version_name}
+                    cp -R docs/* build/input/${product_name}/${version_name}/$language
 
-			cp -R ../docs/${product_name}/${version_name}/en/* build/input/${product_name}-${version_name}
-
-			if [ ! -f "build/input/${product_name}-${version_name}/contents.rst" ]
-			then
-				mv build/input/${product_name}-${version_name}/contents.rst build/input/${product_name}-${version_name}
-			fi
-		done
-	done
+                    cp -R ../docs/${product_name}/${version_name}/${language}/* build/input/${product_name}/${version_name}/${language}
+                fi
+            done
+        done
+    done
 
 	rsync -a homepage/* build/input/homepage --exclude={'*.json','node_modules'}
 }

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -76,55 +76,57 @@ function generate_static_html {
 
                 mv ${output_path}/html/* ${output_path}
 
-		#
-		# Fix broken links.
-		#
+                #
+                # Fix broken links.
+                #
 
-		for html_file_name in `find build/output/${dir_name} -name *.html -type f`
-		do
-			sed -i 's/.md"/.html"/g' ${html_file_name}
-			sed -i 's/.md#/.html#/g' ${html_file_name}
-			sed -i 's/README.html"/index.html"/g' ${html_file_name}
-			sed -i 's/README.html#/index.html#/g' ${html_file_name}
-		done
+                for html_file_name in `find ${output_path} -name *.html -type f`
+                do
+                    sed -i 's/.md"/.html"/g' ${html_file_name}
+                    sed -i 's/.md#/.html#/g' ${html_file_name}
+                    sed -i 's/README.html"/index.html"/g' ${html_file_name}
+                    sed -i 's/README.html#/index.html#/g' ${html_file_name}
+                done
 
-		#
-		# Rename README.html to index.html.
-		#
+                #
+                # Rename README.html to index.html.
+                #
 
-		for readme_file_name in `find build/output/${dir_name} -name *README.html -type f`
-		do
-			mv ${readme_file_name} $(dirname ${readme_file_name})/index.html
-		done
+                for readme_file_name in `find ${output_path} -name *README.html -type f`
+                do
+                    mv ${readme_file_name} $(dirname ${readme_file_name})/index.html
+                done
 
-		#
-		# Update search references for README.html to index.html.
-		#
+                #
+                # Update search references for README.html to index.html.
+                #
 
-		sed -i 's/README"/index"/g' build/output/${dir_name}/searchindex.js
+                sed -i 's/README"/index"/g' ${output_path}/searchindex.js
 
-		#
-		# Make ZIP files.
-		#
+                #
+                # Make ZIP files.
+                #
 
-		for zip_dir_name in `find build/input/${dir_name} -name *.zip -type d`
-		do
-			pushd ${zip_dir_name}
+                for zip_dir_name in `find ${input_path} -name *.zip -type d`
+                do
+                    pushd ${zip_dir_name}
 
-			local zip_file_name=$(basename ${zip_dir_name})
+                    local zip_file_name=$(basename ${zip_dir_name})
 
-			zip -r ${zip_file_name} .
+                    zip -r ${zip_file_name} .
 
-			local output_dir_name=$(dirname ${zip_dir_name})
+                    local output_dir_name=$(dirname ${zip_dir_name})
 
-			output_dir_name=$(dirname ${output_dir_name})
-			output_dir_name=${output_dir_name/input/output}
+                    output_dir_name=$(dirname ${output_dir_name})
+                    output_dir_name=${output_dir_name/input/output}
 
-			popd
+                    popd
 
-			mv ${zip_dir_name}/${zip_file_name} ${output_dir_name}
-		done
-	done
+                    mv ${zip_dir_name}/${zip_file_name} ${output_dir_name}
+                done
+            done
+        done
+    done	
 
 	mv build/output/homepage/* build/output
 

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -54,16 +54,24 @@ function generate_sphinx_input {
 }
 
 function generate_static_html {
-	for dir_name in `find build/input -maxdepth 1 -mindepth 1 -printf "%f\n" -type d`
-	do
+    for product_name in `find build/input/ -maxdepth 1 -mindepth 1 -type d -printf "%f\n"`; do
+		if [[ ${product_name} == homepage ]]
+		then
+			continue
+		fi
 
-		#
-		# Use Sphinx to generate static HTML.
-		#
+        for version_name in `find build/input/${product_name} -maxdepth 1 -mindepth 1 -type d -printf "%f\n"`; do
+            for language in `find build/input/${product_name}/${version_name} -maxdepth 1 -mindepth 1 -type d -printf "%f\n"`; do
+                echo "Generating static html for $product_name $version_name $language"
 
-		sphinx-build -M html build/input/${dir_name} build/output/${dir_name}
+                #
+                # Use Sphinx to generate static HTML for each
+                #   product/version/language. The Homepage content is built
+                #   separately at the end of the function.
+                #
+                sphinx-build -M html build/input/${product_name}/${version_name}/${language} build/output/${product_name}/${version_name}/${language}
 
-		mv build/output/${dir_name}/html/* build/output/${dir_name}
+                mv build/output/${product_name}/${version_name}/${language}/html/* build/output/${product_name}/${version_name}/${language}
 
 		#
 		# Fix broken links.


### PR DESCRIPTION
@thektan originally implemented language support in the site and script. I more or less replayed his work, though there are differences since he was working on a later verison of the script. It's currently building with the proper locale-included URLs, at least on Linux systems. There is an error thrown from the update_examples script that was present even before these changes. We can begin ironing things out once the translation support is re-added and we can push to prod again successfully, which should be the case at this point.
cc @sez11a