### PR TITLE
Make the buildscript support building for the dev (writing) use case

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-readonly CURRENT_DIR_NAME=$(dirname "$0")
+readonly SCRIPT_DIR_NAME=$(dirname "$0")
 
 function check_utils {
 
@@ -124,7 +124,7 @@ function get_product_version_language_dir_name {
 }
 
 function main {
-	pushd "${CURRENT_DIR_NAME}" || exit 1
+	pushd "${SCRIPT_DIR_NAME}" || exit 1
 
 	#
 	# sudo dnf install python3-sphinx

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -21,8 +21,6 @@ function generate_sphinx_input {
 
 	cd ../docs
 
-	git clean -dfx .
-
 	./update_examples.sh && ./update_permissions.sh
 
 	cd ../site
@@ -119,16 +117,21 @@ function generate_static_html {
 
 function get_product_version_language_dir_name {
 	local product_version_language_dir_name=$(echo "${docs_dir_name}" | cut -f3- -d'/')
- 
+
 	echo ${product_version_language_dir_name}
 }
 
 function main {
 	pushd "${SCRIPT_DIR_NAME}" || exit 1
 
-	setup_env
-
 	set_build_type $@
+
+	if [[ ${build_type} == "prod" ]]
+	then
+		pre_clean_for_prod
+	fi
+
+	setup_env
 
 	generate_sphinx_input
 
@@ -147,6 +150,14 @@ function pip_install {
 	done
 }
 
+function pre_clean_for_prod {
+	rm -fr venv
+
+	pushd $(git rev-parse --show-toplevel)/docs
+		git clean -dfx .
+	popd
+}
+
 function set_build_type {
 	if [[ $# -eq 0 ]]
 	then
@@ -160,13 +171,14 @@ function set_build_type {
 		if [[ ${build_type} != "prod" ]]
 		then
 			echo "Invalid Argument: Pass no arguments to build for dev, or pass \"prod\" to build for production."
-			exit
+			exit 1
 		fi
 	fi
+
 	if [[ $# -gt 1 ]]
 	then
 		echo "Too Many Arguments: Pass no arguments to build for dev, or pass \"prod\" to build for production."
-		exit
+		exit 1
 	fi
 }
 

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -128,6 +128,8 @@ function main {
 
 	setup_env
 
+	set_build_type $@
+
 	generate_sphinx_input
 
 	generate_static_html
@@ -143,6 +145,29 @@ function pip_install {
 			pip3 install --disable-pip-version-check ${package_name}
 		fi
 	done
+}
+
+function set_build_type {
+	if [[ $# -eq 0 ]]
+	then
+		build_type="dev"
+	fi
+
+	if [[ $# -eq 1 ]]
+	then
+		build_type=$1
+
+		if [[ ${build_type} != "prod" ]]
+		then
+			echo "Invalid Argument: Pass no arguments to build for dev, or pass \"prod\" to build for production."
+			exit
+		fi
+	fi
+	if [[ $# -gt 1 ]]
+	then
+		echo "Too Many Arguments: Pass no arguments to build for dev, or pass \"prod\" to build for production."
+		exit
+	fi
 }
 
 function setup_env {

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -126,17 +126,7 @@ function get_product_version_language_dir_name {
 function main {
 	pushd "${SCRIPT_DIR_NAME}" || exit 1
 
-	#
-	# sudo dnf install python3-sphinx
-	#
-
-	python3 -m venv venv
-
-	source venv/bin/activate
-
-	check_utils pip3 zip
-
-	pip_install recommonmark sphinx sphinx-copybutton sphinx-intl sphinx-markdown-tables sphinx-notfound-page
+	setup_env
 
 	generate_sphinx_input
 
@@ -153,6 +143,20 @@ function pip_install {
 			pip3 install --disable-pip-version-check ${package_name}
 		fi
 	done
+}
+
+function setup_env {
+	#
+	# sudo dnf install python3-sphinx
+	#
+
+	python3 -m venv venv
+
+	source venv/bin/activate
+
+	check_utils pip3 zip
+
+	pip_install recommonmark sphinx sphinx-copybutton sphinx-intl sphinx-markdown-tables sphinx-notfound-page
 }
 
 function upload_to_server {

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -118,11 +118,9 @@ function generate_static_html {
 }
 
 function get_product_version_language_dir_name {
-	local language=$(echo "${docs_dir_name}" | cut -f5 -d'/')
-	local product=$(echo "${docs_dir_name}" | cut -f3 -d'/')
-	local version=$(echo "${docs_dir_name}" | cut -f4 -d'/')
-
-	echo ${product}/${version}/${language}
+	local product_version_language_dir_name=$(echo "${docs_dir_name}" | cut -f3- -d'/')
+ 
+	echo ${product_version_language_dir_name}
 }
 
 function main {

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -16,14 +16,6 @@ function check_utils {
 	done
 }
 
-function get_product_version_language_dir_name {
-	local language=$(echo "${docs_dir_name}" | cut -f5 -d'/')
-	local product=$(echo "${docs_dir_name}" | cut -f3 -d'/')
-	local version=$(echo "${docs_dir_name}" | cut -f4 -d'/')
-
-	echo ${product}/${version}/${language}
-}
-
 function generate_sphinx_input {
 	rm -fr build
 
@@ -123,6 +115,14 @@ function generate_static_html {
 	mv build/output/homepage/html/* build/output/
 
 	rm -fr build/output/homepage
+}
+
+function get_product_version_language_dir_name {
+	local language=$(echo "${docs_dir_name}" | cut -f5 -d'/')
+	local product=$(echo "${docs_dir_name}" | cut -f3 -d'/')
+	local version=$(echo "${docs_dir_name}" | cut -f4 -d'/')
+
+	echo ${product}/${version}/${language}
 }
 
 function main {


### PR DESCRIPTION
Summary of major changes: 
- more breaking things out into functions
- add logic to parse between the dev and prod use case.
- don't git clean -dfx in the dev case
- add rm -rf venv to the prod case

This is where I begin to really introduce new behavior so I won't be surprised if there are changes you'd like. One thing I think we can discuss is whether to standardize how we change directories. We have a mix of cd and pushd/popd right now.

After we iron out the basic dev use case, I believe the next step should be to introduce support for other OSes, so JR can build for prod without manual intervention and our Windows/MacOS teammates can build the site for testing purposes while writing docs.

I had a comment on one of your recent commits, and I did try to simplify the get_product_version_language function in this PR here: https://github.com/brianchandotcom/liferay-learn/pull/21/commits/84e48e78f02abac5215266a3ca3d42b35f5064d1

Usage: We'd need to begin building for prod by passing the arg "prod" after this. Passing no args builds the dev use case. I don't know if that means we need to update CI? You'll know better than I but I found this line: https://github.com/liferay/liferay-learn/blob/master/.github/workflows/main.yml#L15 