### PR TITLE
Add a node environment to the python virtualenv

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -57,7 +57,15 @@ function configure_env {
 
 	check_utils pip3 zip
 
-	pip_install recommonmark sphinx sphinx-copybutton sphinx-intl sphinx-markdown-tables sphinx-notfound-page
+	pip_install nodeenv recommonmark sphinx sphinx-copybutton sphinx-intl sphinx-markdown-tables sphinx-notfound-page
+
+	# this tool installs a npm environment within our virtual environment. unfortunately it seems to reinstall node every time you run this command, so it is slow. i don't like it for anything but production.
+	nodeenv -p --prebuilt
+
+	# i seem to need to reactivate the python virtual environment for it to work.
+	source venv/bin/activate
+
+	npm_install yo generator-liferay-theme@10.x.x
 }
 
 function generate_sphinx_input {
@@ -184,6 +192,16 @@ function main {
 	generate_static_html
 
 	upload_to_server
+}
+
+function npm_install {
+	for package_name in "${@}"
+	do
+		if [[ -z `npm list --parseable --no-versions --depth=0 --loglevel silent | grep ${package_name}` ]] 
+		then
+			npm install -g ${package_name}
+		fi
+	done
 }
 
 function pip_install {

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -65,7 +65,7 @@ function configure_env {
 
 		source venv/bin/activate
 
-		npm_install yo generator-liferay-theme
+		npm_install generator-liferay-theme yo
 	fi
 }
 

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -62,28 +62,26 @@ function configure_env {
 	if [ "${1}" == "prod" ]
 	then
 		nodeenv -p
-	else
-		nodeenv -p --node=system
+
+		source venv/bin/activate
+
+		npm_install yo generator-liferay-theme
 	fi
-
-	source venv/bin/activate
-
-	npm_install yo generator-liferay-theme
 }
 
 function generate_sphinx_input {
 	rm -fr build
 
-	cd ../docs
-
 	if [ "${1}" == "prod" ]
 	then
+		pushd ../docs
+
 		git clean -dfx .
+
+		./update_examples.sh && ./update_permissions.sh
+
+		pushd ../site
 	fi
-
-	./update_examples.sh && ./update_permissions.sh
-
-	cd ../site
 
 	for docs_dir_name in `find ../docs -maxdepth 4 -mindepth 4 -type f -name "contents.rst" -printf "%h\n"`
 	do

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -59,13 +59,16 @@ function configure_env {
 
 	pip_install nodeenv recommonmark sphinx sphinx-copybutton sphinx-intl sphinx-markdown-tables sphinx-notfound-page
 
-	# this tool installs a npm environment within our virtual environment. unfortunately it seems to reinstall node every time you run this command, so it is slow. i don't like it for anything but production.
-	nodeenv -p --prebuilt
+	if [ "${1}" == "prod" ]
+	then
+		nodeenv -p
+	else
+		nodeenv -p --node=system
+	fi
 
-	# i seem to need to reactivate the python virtual environment for it to work.
 	source venv/bin/activate
 
-	npm_install yo generator-liferay-theme@10.x.x
+	npm_install yo generator-liferay-theme
 }
 
 function generate_sphinx_input {
@@ -197,7 +200,7 @@ function main {
 function npm_install {
 	for package_name in "${@}"
 	do
-		if [[ -z `npm list --parseable --no-versions --depth=0 --loglevel silent | grep ${package_name}` ]] 
+		if [[ -z `npm list -g --parseable --no-versions --depth=0 --loglevel silent | grep ${package_name}` ]]
 		then
 			npm install -g ${package_name}
 		fi


### PR DESCRIPTION
This adds a node environment to the python virtualenv using a tool called [nodeenv](https://github.com/ekalinin/nodeenv).
Note that for the dev case, the final version of the script in this pull request tries to avoid the performance hit of calling node and the theme generator. I've moved the calls to the update scripts within checks for the "prod" case. Reverting the last commit would restore the theme generation to the dev case, but I fear that it would make building for dev almost useless since it takes so long.

These are the performance metrics of the script if we need to build the theme for both prod and dev.
This used to be well under a minute.

$ time ./build_site.sh prod
**real    3m37.386s**

$ time ./build_site.sh
**real    1m35.675s**

In my last commit I've removed the theme building from the dev case to improve the performance. In fact I've moved the calls to update permissions and update examples inside a check for the "prod" argument, because I believe that's where it belongs. If you disagree, reverting the last commit will restore us to the version that always builds the theme.

Here's the performance for the dev case if we can simply skip the update scripts and the nodeenv stuff altogether:

$ time ./build_site.sh
**real    0m58.042s**

cc @sez11a