### PR TITLE
Buildscript: Build prod on windows

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -4,6 +4,19 @@ set -eo pipefail
 
 readonly CURRENT_DIR_NAME=$(dirname "$0")
 
+function activate_venv {
+	if [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]
+	then
+		python3 -m venv venv
+
+		source venv/bin/activate
+	else
+		python -m venv ${PWD}/venv
+
+		source ${PWD}/venv/scripts/activate
+	fi
+}
+
 function check_args {
 	if [[ ${#} -eq 0 ]]
 	then
@@ -51,16 +64,7 @@ function configure_env {
 		rm -fr venv
 	fi
 
-	if [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]
-	then
-		python3 -m venv venv
-
-		source venv/bin/activate
-	else
-		python -m venv ${PWD}/venv
-
-		source ${PWD}/venv/scripts/activate
-	fi
+	activate_venv
 
 	check_utils pip3 zip
 
@@ -70,7 +74,7 @@ function configure_env {
 	then
 		nodeenv -p
 
-		source venv/bin/activate
+		activate_venv
 
 		npm_install generator-liferay-theme yo
 	fi


### PR DESCRIPTION
Prod builds on windows are failing because when we added the nodeenv, we added an extra `source venv/bin/activate` command, which is Linux and Mac friendly but not Windows. I've extracted the logic to a function, `activate venv`, so we don't have to duplicate the check for OS.