### PR TITLE
buildscript windows venv fix

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -11,7 +11,10 @@ function activate_venv {
 
 		source venv/bin/activate
 	else
-		python -m venv ${PWD}/venv
+		if [[ -z `find ${PWD} -maxdepth 1 -mindepth 1 -name venv -type d` ]]
+		then
+			python -m venv ${PWD}/venv
+		fi
 
 		source ${PWD}/venv/scripts/activate
 	fi


### PR DESCRIPTION
JR ran into venv problems on windows. This will check to see if the folder already exists and avoid re-generating it. I did not run into the same issue on Linux so I isolated the fix to just the Windows logic. JR verified a successful prod build on Windows after applying this fix.
cc @jrhoun @sez11a