### PR TITLE
tokenize the git tag in github links, html approach

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -4,7 +4,8 @@ set -eo pipefail
 
 readonly CURRENT_DIR_NAME=$(dirname "$0")
 
-readonly LIFERAY_LEARN_DXP_VERSION=7.3.4-ga5
+readonly LIFERAY_LEARN_DXP_VERSION_TOKEN=%5B%24LIFERAY_LEARN_DXP_VERSION%24%5D
+readonly LIFERAY_LEARN_DXP_VERSION_VALUE=7.3.4-ga5
 
 function activate_venv {
 	if [[ "$(uname)" == "Darwin" || "$(uname)" == "Linux" ]]
@@ -134,7 +135,7 @@ function generate_static_html {
 		do
 			sed -i 's/.md"/.html"/g' ${html_file_name}
 			sed -i 's/.md#/.html#/g' ${html_file_name}
-			sed -i "s/LIFERAY_LEARN_DXP_VERSION/${LIFERAY_LEARN_DXP_VERSION}/g" ${html_file_name}
+			sed -i "s/${LIFERAY_LEARN_DXP_VERSION_TOKEN}/${LIFERAY_LEARN_DXP_VERSION_VALUE}/g" ${html_file_name}
 			sed -i 's/README.html"/index.html"/g' ${html_file_name}
 			sed -i 's/README.html#/index.html#/g' ${html_file_name}
 		done


### PR DESCRIPTION
here we would work with the html interpretation of the token, `%5B%24LIFERAY_LEARN_DXP_VERSION%24%5D`
the replacement happens in the output folder while we're already processing links

cc @sez11a