### PR TITLE
LRDOCS-8203 Add eslint config to turn on full formatting check via npm-scripts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,5 +8,6 @@
 ## Third Party
 ##
 
-	/site/**/*.min.js
+	/site/venv/*
+    /site/**/*.min.js
 	/site/**/modified-search-tools.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+	globals: {
+		$: true,
+	},
+	rules: {
+		'prefer-arrow-callback': 'off',
+	},
+};

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,6 +10,6 @@ jobs:
               run: npm ci
 
             - name: Check Format
-              run: npm run format:check
+              run: npm run check
 name: Format
 on: [pull_request, push]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
 	},
 	"private": true,
 	"scripts": {
+		"fix": "liferay-npm-scripts fix",
+		"check": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts format",
 		"format:check": "liferay-npm-scripts format:check"
 	},

--- a/site/README.md
+++ b/site/README.md
@@ -75,6 +75,8 @@ This builds all products and versions for local testing. Your git index is safe 
 
 ## Formatting
 
-This project is using [@liferay/npm-scripts](https://github.com/liferay/liferay-frontend-projects/tree/master/projects/npm-tools) to format all its `.scss` and `.js` files.
+This project is using [@liferay/npm-scripts](https://github.com/liferay/liferay-frontend-projects/tree/master/projects/npm-tools) to format all its `.scss` and `.js` files. It enforces Liferay specific code styles via ESLint, Prettier, and stylelint.
 
-To automatically format the source, go to the root directory and run `npm run format`. Alternatively, run `npm run format:check` to check if there are any formatting errors.
+To automatically format the source, go to the root directory and run `npm run fix`. Alternatively, run `npm run check` to check if there are any formatting errors.
+
+To only format source code with Prettier, run `npm run format` and `npm run format:check`.

--- a/site/docs/_template/layout.html
+++ b/site/docs/_template/layout.html
@@ -75,12 +75,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </button>
         {% endif %}
 
-        <button aria-haspopup="true" class="btn mobile-menu" id="mobileMenu" onclick="javascript:;" role="navigation" type="button">
-            <svg aria-label="open menu" class="lexicon-icon lexicon-icon-bars" role="img">
+        <button aria-haspopup="true" aria-label="Mobile Menu" class="btn mobile-menu" id="mobileMenu" onclick="javascript:;" role="navigation" type="button">
+            <svg aria-label="Open Menu" class="lexicon-icon lexicon-icon-bars" role="img">
                 <use xlink:href="#bars" />
             </svg>
 
-            <svg aria-label="close menu" class="lexicon-icon lexicon-icon-times" role="img">
+            <svg aria-label="Close Menu" class="lexicon-icon lexicon-icon-times" role="img">
                 <use xlink:href="#times" />
             </svg>
         </button>

--- a/site/docs/_template/page.html
+++ b/site/docs/_template/page.html
@@ -52,8 +52,7 @@
             <div class="doc-nav-wrapper-inner">
                 <div class="info-bar">
                     <label for="productDocumentationSelector">
-                         <select class="form-control" id="productDocumentationSelector"
-                        name="product-documentation-selector">
+                         <select class="form-control" id="productDocumentationSelector">
                             <option value="analytics-cloud">
                                 {% trans %}Analytics Cloud{% endtrans %}
                             </option>

--- a/site/homepage/_template/layout.html
+++ b/site/homepage/_template/layout.html
@@ -75,12 +75,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </button>
         {% endif %}
 
-        <button aria-haspopup="true" class="btn mobile-menu" id="mobileMenu" onclick="javascript:;" role="navigation" type="button">
-            <svg aria-label="open menu" class="lexicon-icon lexicon-icon-bars" role="img">
+        <button aria-haspopup="true" aria-label="Mobile Menu" class="btn mobile-menu" id="mobileMenu" onclick="javascript:;" role="navigation" type="button">
+            <svg aria-label="Open Menu" class="lexicon-icon lexicon-icon-bars" role="img">
                 <use xlink:href="#bars" />
             </svg>
 
-            <svg aria-label="close menu" class="lexicon-icon lexicon-icon-times" role="img">
+            <svg aria-label="Close Menu" class="lexicon-icon lexicon-icon-times" role="img">
                 <use xlink:href="#times" />
             </svg>
         </button>


### PR DESCRIPTION
Added additional configuration to use the full formatting feature provided by @liferay/npm-scripts.

Update: 
@wincent added markdown and YAML support to npm-scripts at https://github.com/liferay/liferay-frontend-projects/pull/103. It hasn't been merged as of yet. I tested the changes and sent to https://github.com/jrhoun/liferay-learn/pull/690 to take a look.