### PR TITLE
LRDOCS-8912 build_site.sh: Drop .zip from the leading dir in the ZIP file

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -178,11 +178,16 @@ function generate_static_html {
 
 		for zip_dir_name in $(find build/input/"${product_version_language_dir_name}" -name *.zip -type d)
 		do
-			pushd "${zip_dir_name}"
+			local zip_parent_dir_name=$(dirname "${zip_dir_name}")
+
+			pushd ${zip_parent_dir_name}
 
 			local zip_file_name=$(basename "${zip_dir_name}")
+			local zip_file_leading_dir_name="${zip_file_name%.*}"
 
-			7z a ${zip_file_name} ../${zip_file_name}\
+			mv ${zip_file_name} ${zip_file_leading_dir_name} 
+
+			7z a ${zip_file_name} ${zip_file_leading_dir_name}\
 
 			local output_dir_name=$(dirname "${zip_dir_name}")
 
@@ -194,7 +199,7 @@ function generate_static_html {
 
 			mkdir -p "${output_dir_name}"
 
-			mv "${zip_dir_name}"/"${zip_file_name}" "${output_dir_name}"
+			mv "${zip_parent_dir_name}"/"${zip_file_name}" "${output_dir_name}"
 		done
 	done
 

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -186,11 +186,7 @@ function generate_static_html {
 
 			local output_dir_name=$(dirname "${zip_dir_name}")
 
-			if [[ "${output_dir_name}" == *"/resources" ]]
-			then
-				output_dir_name=$(dirname "${output_dir_name}")
-			fi
-
+			output_dir_name=$(dirname "${output_dir_name}")
 			output_dir_name=$(dirname "${output_dir_name}")
 			output_dir_name=${output_dir_name/input/output}
 


### PR DESCRIPTION
Hi Brian,

We can't use `unzip liferay-xxxx.zip` on our current ZIP files because the leading dir (with the same name as the ZIP file) clashes with the ZIP file.

> $ unzip liferay-r1s1.zip
Archive:  liferay-r1s1.zip 
checkdir error:  liferay-r1s1.zip exists but is not directory 
                 unable to process liferay-r1s1.zip/. 

By dropping `.zip` from the leading directory name in the ZIP file, executing `unzip liferay-xxxx.zip` extracts the contents, all of which is in a leading folder named `liferay-xxxx`. 

Also, I cleaned up the output_dir_name logic because ALL or our liferay-xxxx.zip dirs are in now in `resources/` parent dirs. 

https://issues.liferay.com/browse/LRDOCS-8912

cc @rbohl

