### PR TITLE
LRDOCS-8916 setup_tutorial.sh: Handle windows env setup

### DIFF
--- a/docs/_template/js/setup_tutorial.sh
+++ b/docs/_template/js/setup_tutorial.sh
@@ -10,19 +10,31 @@ function main {
 		exit
 	fi
 
-	if [[ "${PATH}" != *"${NPM_CONFIG_PREFIX}/bin"* ]]
-	then
-		echo "The environment variable PATH does not include ${NPM_CONFIG_PREFIX}/bin. Add ${NPM_CONFIG_PREFIX}/bin to your PATH. Run this command:
+    local npm_executables_dir_name="${NPM_CONFIG_PREFIX}"/bin
+    local npm_node_modules_dir_name="${NPM_CONFIG_PREFIX}"/lib/node_modules
+    local path_export_command="export PATH=\${PATH}:\${NPM_CONFIG_PREFIX}/bin"
+    
+    if  [[ "$OSTYPE" == "cygwin" ]] &&
+        [[ "$OSTYPE" == "msys" ]]
+    then
+        npm_executables_dir_name="${NPM_CONFIG_PREFIX}"
+        npm_node_modules_dir_name="${NPM_CONFIG_PREFIX}"/node_modules
+        path_export_command="export PATH=\${PATH}:\${NPM_CONFIG_PREFIX}"
+    fi
 
-		export PATH=\${PATH}:\${NPM_CONFIG_PREFIX}/bin"
+	if [[ "${PATH}" != *"${npm_executables_dir_name}"* ]]
+	then
+		echo "The environment variable PATH does not include ${npm_executables_dir_name}. Add it to your PATH. Run this command:
+
+		${path_export_command}"
 
 		exit
 	fi
 
-	if  [ ! -d "${NPM_CONFIG_PREFIX}/lib/node_modules/generator-liferay-fragments" ] ||
-		[ ! -d "${NPM_CONFIG_PREFIX}/lib/node_modules/generator-liferay-js" ] ||
-		[ ! -d "${NPM_CONFIG_PREFIX}/lib/node_modules/generator-liferay-theme" ] ||
-		[ ! -d "${NPM_CONFIG_PREFIX}/lib/node_modules/yo" ]
+	if  [ ! -d "${npm_node_modules_dir_name}/generator-liferay-fragments" ] ||
+		[ ! -d "${npm_node_modules_dir_name}/generator-liferay-js" ] ||
+		[ ! -d "${npm_node_modules_dir_name}/generator-liferay-theme" ] ||
+		[ ! -d "${npm_node_modules_dir_name}/yo" ]
 	then
 		echo "A tutorial dependency is missing. Run this command:
 

--- a/readme/TUTORIAL_CODE_GUIDELINES.md
+++ b/readme/TUTORIAL_CODE_GUIDELINES.md
@@ -1,4 +1,4 @@
-# Example Code Guidelines
+# Tutorial Code Guidelines
 
 ## Table of Contents
 
@@ -34,7 +34,7 @@
 
 ## Purpose
 
-Here are guidelines for tutorial code. It demonstrates starting an example project, describes tutorial code rules, and explains the code review process.
+Here are guidelines for tutorial code. They demonstrate starting an example project, describe tutorial code rules, and explain the code review process.
 
 ## Creating an Example Project
 


### PR DESCRIPTION
I added these three variables:

- `npm_executables_dir_name`: NPM executables directory
- `npm_node_modules_dir_name`: NPM node modules directory
- `path_export_command`:  Printed example command to add the NPM executables directory to the PATH

Here is the example output.

1. Output when NPM_CONFIG_PREFIX isn't set:
```
The environment variable NPM_CONFIG_PREFIX is not set and needs to point to a folder for storing Node packages. Run this command:

                export NPM_CONFIG_PREFIX=~/.npm-global
```

2. Output when NPM executables dir is not in PATH:
```
The environment variable PATH does not include /home/jhinkey/.npm-global/bin. Add it to your PATH. Run this command:

                export PATH=${PATH}:${NPM_CONFIG_PREFIX}/bin
```
On Windows: `/bin` isn't included in either line.

3. Output when missing an NPM node module:
```
A tutorial dependency is missing. Run this command:

                npm install -g generator-liferay-fragments generator-liferay-js generator-liferay-theme yo
```