### PR TITLE
liferay-learn buildscript | handle resources | LRDOCS-9006

### DIFF
--- a/docs/dxp/7.x/en/site-building/developer-guide/developing-page-fragments/adding-configuration-options-to-fragments.md
+++ b/docs/dxp/7.x/en/site-building/developer-guide/developing-page-fragments/adding-configuration-options-to-fragments.md
@@ -32,7 +32,7 @@ First, deploy an example to see how Fragment configuration options work:
 1. Set up the Fragments Toolkit:
 
     ```bash
-    cd liferay-c7f8.zip
+    cd liferay-c7f8
     ```
 
     ```bash

--- a/docs/dxp/7.x/en/site-building/developer-guide/developing-page-fragments/creating-a-contributed-fragment-collection.md
+++ b/docs/dxp/7.x/en/site-building/developer-guide/developing-page-fragments/creating-a-contributed-fragment-collection.md
@@ -39,7 +39,7 @@ First, deploy an example to see what a contributed Fragment Collection looks lik
 1. From the module root, build and deploy the contributed Collection's JAR.
 
     ```bash
-    cd liferay-l3m9.zip
+    cd liferay-l3m9
     ```
 
     ```bash
@@ -132,7 +132,7 @@ You can build and deploy the updated contributed Fragment Collection as you did 
 1. Build the updated contributed Collection's JAR.
 
     ```bash
-    cd liferay-l3m9.zip
+    cd liferay-l3m9
     ```
 
     ```bash

--- a/docs/dxp/7.x/en/site-building/developer-guide/developing-page-fragments/including-default-resources-with-fragments.md
+++ b/docs/dxp/7.x/en/site-building/developer-guide/developing-page-fragments/including-default-resources-with-fragments.md
@@ -25,7 +25,7 @@ First, import an example Fragment Collection to see how Fragment resources work:
 1. Setup up the Fragments Toolkit:
 
     ```bash
-    cd liferay-i6r3.zip
+    cd liferay-i6r3
     ```
 
     ```bash

--- a/docs/dxp/7.x/en/site-building/developer-guide/developing-page-fragments/using-the-fragments-toolkit.md
+++ b/docs/dxp/7.x/en/site-building/developer-guide/developing-page-fragments/using-the-fragments-toolkit.md
@@ -30,7 +30,7 @@ Liferay's [setup_tutorial.sh](https://github.com/liferay/liferay-learn/blob/mast
 1. Set up the Fragments Toolkit and its dependencies using the `setup_tutorial.sh` script.
 
     ```bash 
-    cd liferay-x2y6.zip
+    cd liferay-x2y6
     ```
 
     ```bash 
@@ -47,7 +47,7 @@ The Fragments Toolkit's `yo liferay-fragments` command launches an interface for
    Don't nest Fragments projects. Make sure to create new Fragments projects in their own location, outside of any existing Fragments projects.
 ```
 
-If you're in the `liferay-x2y6.zip` project folder, exit it (e.g., `cd ..`).
+If you're in the `liferay-x2y6` project folder, exit it (e.g., `cd ..`).
 
 Here's how to generate a Fragments Project:
 

--- a/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch.rst
+++ b/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch.rst
@@ -3,10 +3,15 @@ Elasticsearch
 
 .. toctree::
    :maxdepth: 2
-   :glob:
 
-   elasticsearch/*
-
+   elasticsearch/getting-started-with-elasticsearch.md
+   elasticsearch/installing-elasticsearch.md
+   elasticsearch/connecting-to-elasticsearch.md
+   elasticsearch/exercise-installing-elasticsearch.md
+   elasticsearch/troubleshooting-elasticsearch-installation.md
+   elasticsearch/using-the-sidecar-or-embedded-elasticsearch.md
+   elasticsearch/upgrading_elasticsearch.rst
+   
 Elasticsearch is the highly scalable, full-text search engine Liferay uses by default. Elasticsearch is bundled with Liferay for non-production purposes. In production, Liferay requires Elasticsearch running on a separate remote server.
 
 .. important::

--- a/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/upgrading_elasticsearch.rst
+++ b/docs/dxp/7.x/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/upgrading_elasticsearch.rst
@@ -2,11 +2,11 @@ Upgrading Elasticsearch
 =======================
 
 .. toctree::
-   :maxdepth: 2
-   :glob:
+   :maxdepth: 1
 
-   upgrading-elasticsearch/*
-
+   upgrading-elasticsearch/upgrading-search-for-liferay-73.md
+   upgrading-elasticsearch/upgrading-to-elasticsearch-7.md
+   upgrading-elasticsearch/backing-up-elasticsearch.md
 
 Liferay 7.3 brings `new improvements <../../getting-started/whats-new-in-search-for-73.md>`__ for search,including built-in support for Elasticsearch 7. The `compatibility matrix <https://help.liferay.com/hc/en-us/sections/360002103292-Compatibility-Matrix>`__ provides the latest support details.
 

--- a/docs/dxp/7.x/en/using-search/liferay_enterprise_search.rst
+++ b/docs/dxp/7.x/en/using-search/liferay_enterprise_search.rst
@@ -11,7 +11,7 @@ Liferay Enterprise Search
 A Liferay Enterprise Search (LES) subscription provides access to additional search features beyond what's available out of the box with your Liferay DXP subscription. To see a detailed description of the services and features included with LES on your version of Liferay DXP, refer to the official description of LES in the `Liferay DXP Components resource <https://help.liferay.com/hc/en-us/articles/360014400932>`__.  
 
 .. note::
-   LES customers receive a production X-Pack license from Liferay. There can be a delay between your subscription and receipt of the license, but you can enable a `30-day trial <https://www.elastic.co/guide/en/elasticsearch/reference/7.x/start-trial.html>`__ to work with in the meantime.  
+   LES customers receive a `platinum Elasticsearch license <https://www.elastic.co/subscriptions>`__ from Liferay. There can be a delay between your subscription and receipt of the license, but you can enable a `30-day trial <https://www.elastic.co/guide/en/elasticsearch/reference/7.x/start-trial.html>`__ to work with in the meantime.  
 
 Detailed installation and usage instructions are available in the article for each LES feature, including
 

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -173,6 +173,20 @@ function generate_static_html {
 		sed -i 's/README"/index"/g' build/output/"${product_version_language_dir_name}"/searchindex.js
 
 		#
+		# Include unbuilt resources in the built site.
+		#
+
+		for resources_dir in $(find build/input/"${product_version_language_dir_name}" -name resources -type d -prune)
+		do
+			if [[ -n $(find ${resources_dir} -maxdepth 1 -type f) ]]
+			then
+				mkdir -p ${resources_dir/input/output}
+
+				find ${resources_dir} -maxdepth 1 -type f -exec cp {} ${resources_dir/input/output} \;
+			fi
+		done
+
+		#
 		# Make ZIP files.
 		#
 

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -173,16 +173,16 @@ function generate_static_html {
 		sed -i 's/README"/index"/g' build/output/"${product_version_language_dir_name}"/searchindex.js
 
 		#
-		# Include unbuilt resources in the built site.
+		# Include unbuilt resources (root level files only) in the built site.
 		#
 
 		for resources_dir in $(find build/input/"${product_version_language_dir_name}" -name resources -type d -prune)
 		do
-			if [[ -n $(find ${resources_dir} -maxdepth 1 -type f) ]]
+			if [[ -n $(find "${resources_dir}" -maxdepth 1 -type f) ]]
 			then
-				mkdir -p ${resources_dir/input/output}
+				mkdir -p "${resources_dir/input/output}"
 
-				find ${resources_dir} -maxdepth 1 -type f -exec cp {} ${resources_dir/input/output} \;
+				find "${resources_dir}" -maxdepth 1 -type f -exec cp {} "${resources_dir/input/output}" \;
 			fi
 		done
 


### PR DESCRIPTION
Hi Brian, we have a need to include resources in the built site, beyond the code project zips and images. We need a way, for example, to embed videos using pass-through html.
I've written an additional loop, post-build, that does these things:

1. Look for `resources` folders (without recursing beyond the first one--to avoid collecting `src/main/resources`)
2. If there are root level files, make a corresponding dir in the output folder, and copy the files there

Notes:
* I chose to detect only root level files (e.g., get `my-article/resources/01.mp4` but not `my-article/resources/diagrams/drawing.odg`) so that we can still check in the raw materials of drawings and diagrams, but not include them in the built site. We can document this in our writing guidelines.
* I had to use a `find ... -exec cp {}` instead of `cp *` because bash would give a non-0 exit status when it hit a folder in the resources directory.

https://issues.liferay.com/browse/LRDOCS-9006