### PR TITLE
Make the update_examples script git clean -dfx the code projects for prod

### DIFF
--- a/docs/update_examples.sh
+++ b/docs/update_examples.sh
@@ -7,7 +7,7 @@ source ../_common.sh
 function copy_template {
 	local zip_dir_name_pattern="liferay-*.zip"
 
-	if [ -n "${1}" ]
+	if [ -n "${1}" ] && [ "${1}" != "prod" ]
 	then
 		zip_dir_name_pattern="liferay-${1}.zip"
 	fi
@@ -30,6 +30,13 @@ function copy_template {
 			pushd ${zip_dir_name}
 
 			./gradlew classes formatSource
+
+			if [ "${1}" == "prod" ]
+			then
+				git clean -d -e "gradle.properties" -fx .
+
+				cp -fr $(git rev-parse --show-toplevel)/docs/_template/java/* .
+			fi
 
 			popd
 		else

--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -92,7 +92,7 @@ function generate_sphinx_input {
 
 		git clean -dfx .
 
-		./update_examples.sh && ./update_permissions.sh
+		./update_examples.sh "${1}" && ./update_permissions.sh
 
 		pushd ../site
 	fi


### PR DESCRIPTION
Hi Brian, because production builds (`./build_site.sh prod`) call the `update_examples.sh` script, the gradle build files and caches are being zipped up in our src code projects. 

This modification

1. Passes the ${1} arg from build_site to update_examples so we can conditionally operate on a prod build
2. If the "prod" arg is detected, run `git clean -d -e "gradle.properties" -fx` (explanation below) on each .zip folder
3. Re-copy the template contents into the project, since these will also be cleaned

I excluded the gradle.properties file because it's dynamically generated by the update_examples script. Duplicating the logic to regenerate it would be inefficient.
@sez11a @jhinkey @jrhoun