### PR TITLE
LRDOCS-9319 Isolate `contentValue` for decoding

### DIFF
--- a/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/api/document-api-basics/resources/liferay-g9i6.zip/curl/Document_GET_ById_ContentValue.sh
+++ b/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/api/document-api-basics/resources/liferay-g9i6.zip/curl/Document_GET_ById_ContentValue.sh
@@ -1,7 +1,7 @@
 curl \
- "http://localhost:8080/o/headless-delivery/v1.0/documents/${1}?nestedFields=contentValue&fields=contentValue" \
- -u "test@liferay.com:test" \
- | sed -n '2 p' \
- | awk -F':' '{print $2}' \
- | tr -d ' "' \
- | base64 -d
+	"http://localhost:8080/o/headless-delivery/v1.0/documents/${1}?nestedFields=contentValue&fields=contentValue" \
+	-u "test@liferay.com:test" \
+	| sed -n '2 p' \
+	| awk -F':' '{print $2}' \
+	| tr -d ' "' \
+	| base64 -d

--- a/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/api/document-api-basics/resources/liferay-g9i6.zip/curl/Document_GET_ById_ContentValue.sh
+++ b/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/api/document-api-basics/resources/liferay-g9i6.zip/curl/Document_GET_ById_ContentValue.sh
@@ -1,1 +1,7 @@
-IFS=':' read -ra CONTENT <<< $(curl "http://localhost:8080/o/headless-delivery/v1.0/documents/${1}?nestedFields=contentValue&fields=contentValue" -u "test@liferay.com:test" | grep contentValue); echo ${CONTENT[1]} | tr -d '"' | base64 -d
+curl \
+ "http://localhost:8080/o/headless-delivery/v1.0/documents/${1}?nestedFields=contentValue&fields=contentValue" \
+ -u "test@liferay.com:test" \
+ | sed -n '2 p' \
+ | awk -F':' '{print $2}' \
+ | tr -d ' "' \
+ | base64 -d


### PR DESCRIPTION
I improved the content value parsing. But note, since the response is multiple lines, I had to use a few commands. 

# Example response that we're parsing:
```bash
{
  "contentValue" : "Y3VybCBcCgktRiAiZmlsZT1ARG9jdW1lbnRfUE9TVF9Ub1NpdGUuc2giIFwKCS1IICJDb250ZW50LVR5cGU6IG11bHRpcGFydC9mb3JtLWRhdGEiIFwKCS1YIFBPU1QgXAoJImh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9vL2hlYWRsZXNzLWRlbGl2ZXJ5L3YxLjAvc2l0ZXMvJHsxfS9kb2N1bWVudHMiIFwKCS11ICJ0ZXN0QGxpZmVyYXkuY29tOnRlc3Qi"
}
```

# New command:
```bash
curl \
 "http://localhost:8080/o/headless-delivery/v1.0/documents/${1}?nestedFields=contentValue&fields=contentValue" \
 -u "test@liferay.com:test" \
 | sed -n '2 p' \
 | awk -F':' '{print $2}' \
 | tr -d ' "' \
 | base64 -d
```
This table explains the commands:

| command | description | result |
| :--- | :--- | :--- |
| sed ... | prints line 2 | "contentValue" : "Y3V..." |
| awk ... | prints the token after the ":" | "Y3V..." |
| tr ... | trims the spaces and double quotes | Y3V...
| base64 -d | decodes the value | The file contents. |


Also, in the other curl commands that use `-H "Content-Type: ..."` part, I tried switching putting `boundary=...` before `multipart/form-data`, but it results in `UNSUPPORTED_MEDIA_TYPE`.