### PR TITLE
Fix broken liferay-learn prod builds

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -74,7 +74,7 @@ function configure_env {
 
 	if [ "${1}" == "prod" ]
 	then
-		nodeenv -p
+		nodeenv --node=15.14.0 -p
 
 		activate_venv
 


### PR DESCRIPTION
Hey Brian - 

Our prod builds were breaking because nodejs' latest moved to 16.0.0. On the older version our tools worked fine. `nodeenv`'s default behavior was to install the latest version of nodejs. This fixes that behavior by specifying a version to `nodeenv`.

This is the fastest, but probably not the best way to solve this problem.