### PR TITLE
LRDOCS-8910 fix antivirus scanner package

### DIFF
--- a/docs/dxp/latest/en/system-administration/file-storage/providing-an-antivirus-scanner/resources/liferay-y4a2.zip/y4a2-impl/src/main/java/com/acme/y4a2/internal/antivirus/Y4A2AntivirusScanner.java
+++ b/docs/dxp/latest/en/system-administration/file-storage/providing-an-antivirus-scanner/resources/liferay-y4a2.zip/y4a2-impl/src/main/java/com/acme/y4a2/internal/antivirus/Y4A2AntivirusScanner.java
@@ -1,4 +1,4 @@
-package com.acme.antivirus.y4a2.scanner.internal;
+package com.acme.y4a2.internal.antivirus;
 
 import com.liferay.document.library.kernel.antivirus.AntivirusScanner;
 import com.liferay.document.library.kernel.antivirus.AntivirusScannerException;

--- a/site/homepage/package-lock.json
+++ b/site/homepage/package-lock.json
@@ -490,9 +490,9 @@
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
 		},
 		"http-signature": {
 			"version": "1.2.0",

--- a/site/homepage/package-lock.json
+++ b/site/homepage/package-lock.json
@@ -639,9 +639,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"loud-rejection": {
 			"version": "1.6.0",


### PR DESCRIPTION
I followed the packaging pattern of the AntivirusScanner interface that this scanner implements `com.liferay.document.library.kernel.antivirus.AntivirusScanner`.

Note, I haven't seen any examples of implemention classes using the parts before `kernel` (like `document.library`) after `internal`. So I gave `Y4A2AntivirusScanner` this package:

```java
package com.acme.y4a2.internal.antivirus;
```

The new package follows SF's [Java Package Formatting](https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/documentation/package.markdown#classes-extending-implementing-or-using-kernel-classes) for classes extending, implementing, or using kernel classes.