### PR TITLE
LRDOCS-9492 Ignore .vscode files everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .gradle
+.vscode
 docs/**/build/
 docs/**/bundles/
 docs/**/liferay-????-theme.war
@@ -10,7 +11,6 @@ docs/**/liferay-????.zip/**/.classpath
 docs/**/liferay-????.zip/**/.metadata/
 docs/**/liferay-????.zip/**/.project
 docs/**/liferay-????.zip/**/.settings/
-docs/**/liferay-????.zip/**/.vscode/
 docs/**/liferay-????.zip/.gradle/
 docs/**/liferay-????.zip/.yo-rc.json
 docs/**/liferay-????.zip/gradle.properties


### PR DESCRIPTION
Several tech writers are using VSCode editor for editing articles, in addition to code. So we'd like the flexibility to use a VSCode project anywhere in the liferay-learn repo. :-)

https://issues.liferay.com/browse/LRDOCS-9492