### PR TITLE
Suppress JavaExceptionCheck until it's fixed in SF

### DIFF
--- a/docs/_template/java/source-formatter-suppressions.xml
+++ b/docs/_template/java/source-formatter-suppressions.xml
@@ -6,5 +6,6 @@
 	</checkstyle>
 	<source-check>
 		<suppress checks="CopyrightCheck" files=".*" />
+        <suppress checks="JavaExceptionCheck" files=".*" />
 	</source-check>
 </suppressions>

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -7,6 +7,7 @@
 	<source-check>
 		<suppress checks="CopyrightCheck" files=".*" />
 		<suppress checks="JavaClassNameCheck" files=".*" />
+        <suppress checks="JavaExceptionCheck" files=".*" />
 		<suppress checks="JavaPackagePathCheck" files=".*" />
 	</source-check>
 </suppressions>


### PR DESCRIPTION
Hi Brian,

I reported the following [issue](https://liferay.slack.com/archives/C1SJ64S9X/p1622822362017500) to Hugo. He confirmed the issue too and said he'd let me know when he's fixed it ...

When I run SF, it complained about an exception variable name and suggested a more descriptive one. But when I use that suggested name and re-run SF, SF changes it back to the original name and complains again. 

Steps:
1. Pull my branch https://github.com/jhinkey/liferay-learn/tree/lrdocs-8961-sending-messages-sync-default-2 or copy my module https://github.com/jhinkey/liferay-learn/tree/lrdocs-8961-sending-messages-sync-default-2/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-default-synchronous-messaging/resources/liferay-m4q7.zip/m4q7-baker-impl
2. cd dxp/latest/en/developing-applications/core-frameworks/message-bus/using-default-synchronous-messaging/resources/liferay-m4q7.zip/m4q7-baker-impl
3. ../gradlew formatSource

> Task :m4q7-baker-impl:formatSource FAILED
Scanning for files...
Initializing checks...
Processing checks: 100% completed
Rename exception variable 'mbe' to 'messageBusException': /home/jhinkey/git/liferay-learn/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-default-synchronous-messaging/resources/liferay-m4q7.zip/m4q7-baker-impl/src/main/java/com/acme/m4q7/baker/osgi/commands/M4Q7BakerOSGiCommands.java 53 (Checkstyle:ExceptionVariableNameCheck)
 >                   
> java.lang.Exception: Found 1 formatting issues:
> Rename exception variable 'mbe' to 'messageBusException': /home/jhinkey/git/liferay-learn/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-default-synchronous-messaging/resources/liferay-m4q7.zip/m4q7-baker-impl/src/main/java/com/acme/m4q7/baker/osgi/commands/M4Q7BakerOSGiCommands.java 53 (Checkstyle:ExceptionVariableNameCheck)
>
>        at com.liferay.source.formatter.SourceFormatter.format(SourceFormatter.java:459)
>        at com.liferay.source.formatter.SourceFormatter.main(SourceFormatter.java:302)

4. Rename exception variable 'mbe' to 'messageBusException' and save the change.
5. ../gradlew formatSource

Result: The variable is changed back to 'mbe' and SF complains again.

Expected Result: The code isn't changed and SF succeeds without complaint.