### PR TITLE
LRDOCS-9476 Code for 'Using Direct Synchronous Messaging'

### DIFF
--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-able-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-able-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme X6N5 Able Implementation
+Bundle-SymbolicName: com.acme.x6n5.able.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-able-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-able-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-able-impl/src/main/java/com/acme/x6n5/able/internal/messaging/X6N5AbleMessagingConfigurator.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-able-impl/src/main/java/com/acme/x6n5/able/internal/messaging/X6N5AbleMessagingConfigurator.java
@@ -1,0 +1,42 @@
+package com.acme.x6n5.able.internal.messaging;
+
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component
+public class X6N5AbleMessagingConfigurator {
+
+	@Activate
+	private void _activate(BundleContext bundleContext) {
+		Destination destination = _destinationFactory.createDestination(
+			DestinationConfiguration.createSynchronousDestinationConfiguration(
+				"acme/x6n5_able"));
+
+		_serviceRegistration = bundleContext.registerService(
+			Destination.class, destination,
+			MapUtil.singletonDictionary(
+				"destination.name", destination.getName()));
+	}
+
+	@Deactivate
+	private void _deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	@Reference
+	private DestinationFactory _destinationFactory;
+
+	private ServiceRegistration<Destination> _serviceRegistration;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme X6N5 Baker Implementation
+Bundle-SymbolicName: com.acme.x6n5.baker.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/src/main/java/com/acme/x6n5/baker/osgi/commands/X6N5BakerOSGiCommands.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/src/main/java/com/acme/x6n5/baker/osgi/commands/X6N5BakerOSGiCommands.java
@@ -1,0 +1,90 @@
+package com.acme.x6n5.baker.osgi.commands;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBusException;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.messaging.sender.SynchronousMessageSender;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+	property = {
+		"destination.name=" + X6N5BakerOSGiCommands.X6N5_BAKER_DESTINATION,
+		"osgi.command.function=sendMessage", "osgi.command.scope=x6n5.baker"
+	},
+	service = MessageListener.class
+)
+public class X6N5BakerOSGiCommands implements MessageListener {
+
+	public static final String X6N5_BAKER_DESTINATION = "acme/x6n5_baker";
+
+	@Override
+	public void receive(Message message) {
+		if (_log.isInfoEnabled()) {
+			Object payload = message.getPayload();
+
+			_log.info("Received message payload " + payload.toString());
+		}
+	}
+
+	public void sendMessage(String payload) {
+		try {
+			Message message = new Message();
+
+			message.setPayload(payload);
+
+			message.setResponseDestinationName("acme/x6n5_baker");
+
+			_directSynchronousMessageSender.send("acme/x6n5_able", message);
+
+			if (_log.isInfoEnabled()) {
+				_log.info("Invoked SynchronousMessageSender#sent(String, Message) in DIRECT mode");
+			}
+		}
+		catch (MessageBusException messageBusException) {
+			messageBusException.printStackTrace();
+		}
+	}
+
+	@Activate
+	private void _activate(BundleContext bundleContext) {
+		Destination destination = _destinationFactory.createDestination(
+			DestinationConfiguration.createSynchronousDestinationConfiguration(
+				"acme/x6n5_baker"));
+
+		_serviceRegistration = bundleContext.registerService(
+			Destination.class, destination,
+			MapUtil.singletonDictionary(
+				"destination.name", destination.getName()));
+	}
+
+	@Deactivate
+	private void _deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		X6N5BakerOSGiCommands.class);
+
+	@Reference
+	private DestinationFactory _destinationFactory;
+
+	@Reference(target = "(mode=DIRECT)")
+	private SynchronousMessageSender _directSynchronousMessageSender;
+
+	private ServiceRegistration<Destination> _serviceRegistration;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/src/main/java/com/acme/x6n5/baker/osgi/commands/X6N5BakerOSGiCommands.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/src/main/java/com/acme/x6n5/baker/osgi/commands/X6N5BakerOSGiCommands.java
@@ -46,10 +46,10 @@ public class X6N5BakerOSGiCommands implements MessageListener {
 
 			message.setResponseDestinationName("acme/x6n5_baker");
 
-			_directSynchronousMessageSender.send("acme/x6n5_able", message);
+			Object response = _directSynchronousMessageSender.send("acme/x6n5_able", message);
 
 			if (_log.isInfoEnabled()) {
-				_log.info("Invoked SynchronousMessageSender#sent(String, Message) in DIRECT mode");
+				_log.info("SynchronousMessageSender#send(String, Message) returned " + response);
 			}
 		}
 		catch (MessageBusException messageBusException) {

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/src/main/java/com/acme/x6n5/baker/osgi/commands/X6N5BakerOSGiCommands.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/src/main/java/com/acme/x6n5/baker/osgi/commands/X6N5BakerOSGiCommands.java
@@ -2,41 +2,20 @@ package com.acme.x6n5.baker.osgi.commands;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.messaging.Destination;
-import com.liferay.portal.kernel.messaging.DestinationConfiguration;
-import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBusException;
-import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.messaging.sender.SynchronousMessageSender;
-import com.liferay.portal.kernel.util.MapUtil;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 @Component(
 	property = {
-		"destination.name=" + X6N5BakerOSGiCommands.X6N5_BAKER_DESTINATION,
 		"osgi.command.function=sendMessage", "osgi.command.scope=x6n5.baker"
 	},
-	service = MessageListener.class
+	service = Object.class
 )
-public class X6N5BakerOSGiCommands implements MessageListener {
-
-	public static final String X6N5_BAKER_DESTINATION = "acme/x6n5_baker";
-
-	@Override
-	public void receive(Message message) {
-		if (_log.isInfoEnabled()) {
-			Object payload = message.getPayload();
-
-			_log.info("Received message payload " + payload.toString());
-		}
-	}
+public class X6N5BakerOSGiCommands {
 
 	public void sendMessage(String payload) {
 		try {
@@ -44,12 +23,13 @@ public class X6N5BakerOSGiCommands implements MessageListener {
 
 			message.setPayload(payload);
 
-			message.setResponseDestinationName("acme/x6n5_baker");
-
-			Object response = _directSynchronousMessageSender.send("acme/x6n5_able", message);
+			Object response = _directSynchronousMessageSender.send(
+				"acme/x6n5_able", message);
 
 			if (_log.isInfoEnabled()) {
-				_log.info("SynchronousMessageSender#send(String, Message) returned " + response);
+				_log.info(
+					"SynchronousMessageSender#send(String, Message) returned " +
+						response);
 			}
 		}
 		catch (MessageBusException messageBusException) {
@@ -57,34 +37,10 @@ public class X6N5BakerOSGiCommands implements MessageListener {
 		}
 	}
 
-	@Activate
-	private void _activate(BundleContext bundleContext) {
-		Destination destination = _destinationFactory.createDestination(
-			DestinationConfiguration.createSynchronousDestinationConfiguration(
-				"acme/x6n5_baker"));
-
-		_serviceRegistration = bundleContext.registerService(
-			Destination.class, destination,
-			MapUtil.singletonDictionary(
-				"destination.name", destination.getName()));
-	}
-
-	@Deactivate
-	private void _deactivate() {
-		if (_serviceRegistration != null) {
-			_serviceRegistration.unregister();
-		}
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		X6N5BakerOSGiCommands.class);
 
-	@Reference
-	private DestinationFactory _destinationFactory;
-
 	@Reference(target = "(mode=DIRECT)")
 	private SynchronousMessageSender _directSynchronousMessageSender;
-
-	private ServiceRegistration<Destination> _serviceRegistration;
 
 }

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/src/main/java/com/acme/x6n5/baker/osgi/commands/X6N5MessageSenderOSGiCommands.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-baker-impl/src/main/java/com/acme/x6n5/baker/osgi/commands/X6N5MessageSenderOSGiCommands.java
@@ -15,7 +15,7 @@ import org.osgi.service.component.annotations.Reference;
 	},
 	service = Object.class
 )
-public class X6N5BakerOSGiCommands {
+public class X6N5MessageSenderOSGiCommands {
 
 	public void sendMessage(String payload) {
 		try {
@@ -38,7 +38,7 @@ public class X6N5BakerOSGiCommands {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		X6N5BakerOSGiCommands.class);
+		X6N5MessageSenderOSGiCommands.class);
 
 	@Reference(target = "(mode=DIRECT)")
 	private SynchronousMessageSender _directSynchronousMessageSender;

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-charlie-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-charlie-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme X6N5 Charlie Implementation
+Bundle-SymbolicName: com.acme.x6n5.charlie.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-charlie-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-charlie-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-charlie-impl/src/main/java/com/acme/x6n5/charlie/internal/messaging/X6N5CharlieMessageListener.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-charlie-impl/src/main/java/com/acme/x6n5/charlie/internal/messaging/X6N5CharlieMessageListener.java
@@ -1,0 +1,49 @@
+package com.acme.x6n5.charlie.internal.messaging;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.messaging.sender.SynchronousMessageSender;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+	property = "destination.name=acme/x6n5_able",
+	service = MessageListener.class
+)
+public class X6N5CharlieMessageListener implements MessageListener {
+
+	@Override
+	public void receive(Message message) {
+		if (_log.isInfoEnabled()) {
+			Object payload = message.getPayload();
+
+			_log.info("Received message payload " + payload.toString());
+		}
+
+		//TODO uncomment these lines if you want to send a response
+		// Message responseMessage = new Message();
+
+		// responseMessage.setDestinationName(
+		// 	message.getResponseDestinationName());
+		// responseMessage.setPayload(
+		// 	"X6N5CharlieMessageListener#receive(Message)");
+		// responseMessage.setResponseId(message.getResponseId());
+
+		// _messageBus.sendMessage(
+		// 	message.getResponseDestinationName(), responseMessage);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		X6N5CharlieMessageListener.class);
+
+	@Reference(target = "(mode=DIRECT)")
+	private SynchronousMessageSender _directSynchronousMessageSender;
+
+	@Reference
+	private MessageBus _messageBus;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-charlie-impl/src/main/java/com/acme/x6n5/charlie/internal/messaging/X6N5CharlieMessageListener.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-charlie-impl/src/main/java/com/acme/x6n5/charlie/internal/messaging/X6N5CharlieMessageListener.java
@@ -24,17 +24,18 @@ public class X6N5CharlieMessageListener implements MessageListener {
 			_log.info("Received message payload " + payload.toString());
 		}
 
-		//TODO uncomment these lines if you want to send a response
-		// Message responseMessage = new Message();
+		// message.setResponse("X6N5CharlieMessageListener");
 
-		// responseMessage.setDestinationName(
-		// 	message.getResponseDestinationName());
-		// responseMessage.setPayload(
-		// 	"X6N5CharlieMessageListener#receive(Message)");
-		// responseMessage.setResponseId(message.getResponseId());
+		Message responseMessage = new Message();
 
-		// _messageBus.sendMessage(
-		// 	message.getResponseDestinationName(), responseMessage);
+		responseMessage.setDestinationName(
+			message.getResponseDestinationName());
+		responseMessage.setPayload(
+			"X6N5CharlieMessageListener");
+		responseMessage.setResponseId(message.getResponseId());
+
+		_messageBus.sendMessage(
+			message.getResponseDestinationName(), responseMessage);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-charlie-impl/src/main/java/com/acme/x6n5/charlie/internal/messaging/X6N5CharlieMessageListener.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-charlie-impl/src/main/java/com/acme/x6n5/charlie/internal/messaging/X6N5CharlieMessageListener.java
@@ -3,12 +3,9 @@ package com.acme.x6n5.charlie.internal.messaging;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
-import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.MessageListener;
-import com.liferay.portal.kernel.messaging.sender.SynchronousMessageSender;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 @Component(
 	property = "destination.name=acme/x6n5_able",
@@ -24,27 +21,10 @@ public class X6N5CharlieMessageListener implements MessageListener {
 			_log.info("Received message payload " + payload.toString());
 		}
 
-		// message.setResponse("X6N5CharlieMessageListener");
-
-		Message responseMessage = new Message();
-
-		responseMessage.setDestinationName(
-			message.getResponseDestinationName());
-		responseMessage.setPayload(
-			"X6N5CharlieMessageListener");
-		responseMessage.setResponseId(message.getResponseId());
-
-		_messageBus.sendMessage(
-			message.getResponseDestinationName(), responseMessage);
+		message.setResponse("X6N5CharlieMessageListener");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		X6N5CharlieMessageListener.class);
-
-	@Reference(target = "(mode=DIRECT)")
-	private SynchronousMessageSender _directSynchronousMessageSender;
-
-	@Reference
-	private MessageBus _messageBus;
 
 }

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-dog-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-dog-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme X6N5 Dog Implementation
+Bundle-SymbolicName: com.acme.x6n5.dog.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-dog-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-dog-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-dog-impl/src/main/java/com/acme/x6n5/dog/internal/messaging/X6N5DogMessageListener.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-dog-impl/src/main/java/com/acme/x6n5/dog/internal/messaging/X6N5DogMessageListener.java
@@ -1,0 +1,37 @@
+package com.acme.x6n5.dog.internal.messaging;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.messaging.sender.SynchronousMessageSender;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+	property = "destination.name=acme/x6n5_able",
+	service = MessageListener.class
+)
+public class X6N5DogMessageListener implements MessageListener {
+
+	@Override
+	public void receive(Message message) {
+		if (_log.isInfoEnabled()) {
+			Object payload = message.getPayload();
+
+			_log.info("Received message payload " + payload.toString());
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		X6N5DogMessageListener.class);
+
+	@Reference(target = "(mode=DIRECT)")
+	private SynchronousMessageSender _directSynchronousMessageSender;
+
+	@Reference
+	private MessageBus _messageBus;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-dog-impl/src/main/java/com/acme/x6n5/dog/internal/messaging/X6N5DogMessageListener.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip/x6n5-dog-impl/src/main/java/com/acme/x6n5/dog/internal/messaging/X6N5DogMessageListener.java
@@ -3,12 +3,9 @@ package com.acme.x6n5.dog.internal.messaging;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
-import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.MessageListener;
-import com.liferay.portal.kernel.messaging.sender.SynchronousMessageSender;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 @Component(
 	property = "destination.name=acme/x6n5_able",
@@ -23,15 +20,11 @@ public class X6N5DogMessageListener implements MessageListener {
 
 			_log.info("Received message payload " + payload.toString());
 		}
+
+		message.setResponse("X6N5DogMessageListener");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		X6N5DogMessageListener.class);
-
-	@Reference(target = "(mode=DIRECT)")
-	private SynchronousMessageSender _directSynchronousMessageSender;
-
-	@Reference
-	private MessageBus _messageBus;
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-9476

I renamed the OSGi Commands class to `X6N5MessageSenderOSGiCommands`.

The example show the synchronous manner in which the caller thread processes each message listener's `receive` method before continuing in the sender class.

Steps:
1. Start a 7.3+ container.
1. Add a Workspace to the example project.
    ```
    cd liferay-learn/docs
    ./update_example.sh x6n5
    ```
1. Deploy the example.
    ```bash
    cd dxp/latest/en/developing-applications/core-frameworks/message-bus/using-direct-synchronous-messaging/resources/liferay-x6n5.zip
    ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
    ```
1. Sign in to DXP/Portal and go to the Gogo Shell Console.
1. Execute the following Gogo Shell command:
    **g!** `x6n5.baker:sendMessage foo`

Your results should look like this...

```bash
INFO  [pipe-x6n5.baker:sendMessage Foo][X6N5CharlieMessageListener:22] Received message payload Foo
INFO  [pipe-x6n5.baker:sendMessage Foo][X6N5DogMessageListener:22] Received message payload Foo
INFO  [pipe-x6n5.baker:sendMessage Foo][X6N5MessageSenderOSGiCommands:40] SynchronousMessageSender#send(String, Message) returned X6N5CharlieMessageListener
```

The thread processed the message listeners _before_ continuing with logic after the `.send` call.