### PR TITLE
liferay-learn buildscript | do not change github links | LRDOCS-8435

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -170,7 +170,7 @@ function generate_static_html {
 
 		for html_file_name in $(find build/output/"${product_version_language_dir_name}" -name *.html -type f)
 		do
-			sed -i 's/.md"/.html"/g' ${html_file_name}
+			sed -i '/github\.com\/liferay\/liferay\-learn/ ! s/.md"/.html"/g' ${html_file_name}
 			sed -i 's/.md#/.html#/g' ${html_file_name}
 			sed -i 's/README.html"/index.html"/g' ${html_file_name}
 			sed -i 's/README.html#/index.html#/g' ${html_file_name}


### PR DESCRIPTION
This adds an exclusion to the first "fix broken links" `sed` command; ironically, the existing command is breaking the "Contribute to Github" links.
Basically I'm telling `sed` to ignore lines that have a match to the string `github.com/liferay/liferay-learn`.
https://issues.liferay.com/browse/LRDOCS-8435
@jrhoun @sez11a

If this is a bad solution, we should find a good one or remove the button from our page template.