### PR TITLE
LRDOCS-8958 Code for 'Listening for Registration Events'

### DIFF
--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-able-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-able-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme S3Z9 Able Implementation
+Bundle-SymbolicName: com.acme.s3z9.able.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-able-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-able-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-able-impl/src/main/java/com/acme/s3z9/able/internal/messaging/S3Z9AbleMessageBusEventListener.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-able-impl/src/main/java/com/acme/s3z9/able/internal/messaging/S3Z9AbleMessageBusEventListener.java
@@ -1,0 +1,31 @@
+package com.acme.s3z9.able.internal.messaging;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.MessageBusEventListener;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = MessageBusEventListener.class)
+public class S3Z9AbleMessageBusEventListener
+	implements MessageBusEventListener {
+
+	@Override
+	public void destinationAdded(Destination destination) {
+		if (_log.isInfoEnabled()) {
+			_log.info("Added destination " + destination.getName());
+		}
+	}
+
+	@Override
+	public void destinationRemoved(Destination destination) {
+		if (_log.isInfoEnabled()) {
+			_log.info("Removed destination " + destination.getName());
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		S3Z9AbleMessageBusEventListener.class);
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-baker-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-baker-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme S3Z9 Baker Implementation
+Bundle-SymbolicName: com.acme.s3z9.baker.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-baker-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-baker-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-baker-impl/src/main/java/com/acme/s3z9/baker/internal/messaging/S3Z9BakerMessagingConfigurator.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-baker-impl/src/main/java/com/acme/s3z9/baker/internal/messaging/S3Z9BakerMessagingConfigurator.java
@@ -1,0 +1,42 @@
+package com.acme.s3z9.baker.internal.messaging;
+
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component
+public class S3Z9BakerMessagingConfigurator {
+
+	@Activate
+	private void _activate(BundleContext bundleContext) {
+		Destination destination = _destinationFactory.createDestination(
+			DestinationConfiguration.createSerialDestinationConfiguration(
+				"acme/s3z9_baker"));
+
+		_serviceRegistration = bundleContext.registerService(
+			Destination.class, destination,
+			MapUtil.singletonDictionary(
+				"destination.name", destination.getName()));
+	}
+
+	@Deactivate
+	private void _deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	@Reference
+	private DestinationFactory _destinationFactory;
+
+	private ServiceRegistration<Destination> _serviceRegistration;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-charlie-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-charlie-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme S3Z9 Charlie Implementation
+Bundle-SymbolicName: com.acme.s3z9.charlie.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-charlie-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-charlie-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-charlie-impl/src/main/java/com/acme/s3z9/charlie/internal/messaging/S3Z9CharlieDestinationEventListener.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-charlie-impl/src/main/java/com/acme/s3z9/charlie/internal/messaging/S3Z9CharlieDestinationEventListener.java
@@ -1,0 +1,38 @@
+package com.acme.s3z9.charlie.internal.messaging;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.DestinationEventListener;
+import com.liferay.portal.kernel.messaging.MessageListener;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+	property = "destination.name=acme/s3z9_baker",
+	service = DestinationEventListener.class
+)
+public class S3Z9CharlieDestinationEventListener
+	implements DestinationEventListener {
+
+	@Override
+	public void messageListenerRegistered(
+		String destinationName, MessageListener messageListener) {
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Registered message listener to " + destinationName);
+		}
+	}
+
+	@Override
+	public void messageListenerUnregistered(
+		String destinationName, MessageListener messageListener) {
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Unregistered message listener from " + destinationName);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		S3Z9CharlieDestinationEventListener.class);
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-dog-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-dog-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme S3Z9 Dog Implementation
+Bundle-SymbolicName: com.acme.s3z9.dog.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-dog-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-dog-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-dog-impl/src/main/java/com/acme/s3z9/dog/internal/messaging/S3Z9DogMessageListener.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/listening-for-registration-events/resources/liferay-s3z9.zip/s3z9-dog-impl/src/main/java/com/acme/s3z9/dog/internal/messaging/S3Z9DogMessageListener.java
@@ -1,0 +1,18 @@
+package com.acme.s3z9.dog.internal.messaging;
+
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageListener;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+	property = "destination.name=acme/s3z9_baker",
+	service = MessageListener.class
+)
+public class S3Z9DogMessageListener implements MessageListener {
+
+	@Override
+	public void receive(Message message) {
+	}
+
+}


### PR DESCRIPTION
Deploy the modules separately in order (able, baker, charlie, dog) to demonstrate the listeners. Here's what happens:

1. able's class listens for new destinations.
2. baker's class adds a destination; able's class logs the event.
3. charlie's class listens for new message listener registrations on the destination.
4. dog's class registers a message listener; charlie's class logs the event.

https://issues.liferay.com/browse/LRDOCS-8958