### PR TITLE
LRDOCS-9512 Code for 'Tuning Messaging Performance'

### DIFF
--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme W3R2 Able Implementation
+Bundle-SymbolicName: com.acme.w3r2.able.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/src/main/java/com/acme/w3r2/able/internal/messaging/W3R2AbleMessagingConfigurator.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/src/main/java/com/acme/w3r2/able/internal/messaging/W3R2AbleMessagingConfigurator.java
@@ -1,0 +1,54 @@
+package com.acme.w3r2.able.internal.messaging;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component
+public class W3R2AbleMessagingConfigurator {
+
+	@Activate
+	private void _activate(BundleContext bundleContext) {
+		DestinationConfiguration destinationConfiguration =
+			DestinationConfiguration.createSerialDestinationConfiguration(
+				"acme/w3r2_able");
+
+		if (_log.isInfoEnabled()) {
+			_log.info(destinationConfiguration.toString());
+		}
+
+		Destination destination = _destinationFactory.createDestination(
+			destinationConfiguration);
+
+		_serviceRegistration = bundleContext.registerService(
+			Destination.class, destination,
+			MapUtil.singletonDictionary(
+				"destination.name", destination.getName()));
+	}
+
+	@Deactivate
+	private void _deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		W3R2AbleMessagingConfigurator.class);
+
+	@Reference
+	private DestinationFactory _destinationFactory;
+
+	private ServiceRegistration<Destination> _serviceRegistration;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme W3R2 Baker Implementation
+Bundle-SymbolicName: com.acme.w3r2.baker.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/src/main/java/com/acme/w3r2/baker/internal/messaging/W3R2BakerMessageListenerManager.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/src/main/java/com/acme/w3r2/baker/internal/messaging/W3R2BakerMessageListenerManager.java
@@ -1,0 +1,55 @@
+package com.acme.w3r2.baker.internal.messaging;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.messaging.MessageListener;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component
+public class W3R2BakerMessageListenerManager {
+
+	@Activate
+	private void _activate() {
+		for (int i = 0; i < 10; i++) {
+			_messageBus.registerMessageListener(
+				"acme/w3r2_able",
+				new MessageListener() {
+
+					@Override
+					public void receive(Message message) {
+						if (_log.isInfoEnabled()) {
+							Object payload = message.getPayload();
+
+							_log.info(
+								"Received message payload " +
+									payload.toString());
+						}
+					}
+
+				});
+		}
+	}
+
+	@Deactivate
+	private void _deactivate() {
+		Destination destination = _messageBus.getDestination("acme/w3r2_able");
+
+		if (destination != null) {
+			destination.unregisterMessageListeners();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		W3R2BakerMessageListenerManager.class);
+
+	@Reference
+	private MessageBus _messageBus;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme W3R2 Charlie Implementation
+Bundle-SymbolicName: com.acme.w3r2.charlie.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/src/main/java/com/acme/w3r2/charlie/internal/osgi/commands/W3R2CharlieOSGiCommands.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/src/main/java/com/acme/w3r2/charlie/internal/osgi/commands/W3R2CharlieOSGiCommands.java
@@ -1,0 +1,59 @@
+package com.acme.w3r2.charlie.internal.osgi.commands;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationStatistics;
+import com.liferay.portal.kernel.messaging.MessageBus;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+	property = {
+		"osgi.command.function=listDestinationStats", "osgi.command.scope=w3r2"
+	},
+	service = W3R2CharlieOSGiCommands.class
+)
+public class W3R2CharlieOSGiCommands {
+
+	public void listDestinationStats() {
+		if (_log.isInfoEnabled()) {
+			Destination destination = _messageBus.getDestination(
+				"acme/w3r2_able");
+
+			StringBundler sb = new StringBundler(16);
+
+			sb.append("acme/w3r2_able message listener count ");
+			sb.append(destination.getMessageListenerCount());
+
+			DestinationStatistics destinationStatistics =
+				destination.getDestinationStatistics();
+
+			sb.append(", active thread count ");
+			sb.append(destinationStatistics.getActiveThreadCount());
+			sb.append(", current thread count ");
+			sb.append(destinationStatistics.getCurrentThreadCount());
+			sb.append(", largest thread count ");
+			sb.append(destinationStatistics.getLargestThreadCount());
+			sb.append(", max thread pool size ");
+			sb.append(destinationStatistics.getMaxThreadPoolSize());
+			sb.append(", min thread pool size ");
+			sb.append(destinationStatistics.getMinThreadPoolSize());
+			sb.append(", pending message count ");
+			sb.append(destinationStatistics.getPendingMessageCount());
+			sb.append(", sent message count ");
+			sb.append(destinationStatistics.getSentMessageCount());
+
+			_log.info(sb.toString());
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		W3R2CharlieOSGiCommands.class);
+
+	@Reference
+	private MessageBus _messageBus;
+
+}


### PR DESCRIPTION
1. Build and deploy the example project modules.

    ```bash
    cd liferay-w3r2.zip
    ```

    ```bash
    ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
    ```
    
    The messaging configurator logs the `DestinationConfiguration`, including its type, max queue size, starting thread pool size, and max thread pool size.
    
1. Visit the Liferay instance with your browser at `http://localhost:8080` and sign in using your credentials.

1. Open the Script console.

1. Send messages by entering the following code in the script field and executing it.

    ```groovy
    import com.liferay.portal.kernel.messaging.*;

	MessageBusUtil.sendMessage(
		"acme/w3r2_able",
		new Message() {
			{
				setPayload("foo");
			}
		});
    ```
    
  1. In Gogo shell, execute the `w3r2:listDestinationStats` command to list the destination's statistics.
   
In the tutorial, after examining the `DestinationConfiguration` getters and `DestinationStatistics` getters, I'll have them change to a parallel destination and increase its starting and max thread sizes.