### PR TITLE
LRDOCS-8985 MVC Render Command code

### DIFF
--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme A4P1 Web
+Bundle-SymbolicName: com.acme.a4p1.web
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/java/com/acme/a4p1/web/internal/portlet/A4P1Portlet.java
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/java/com/acme/a4p1/web/internal/portlet/A4P1Portlet.java
@@ -1,0 +1,20 @@
+package com.acme.a4p1.web.internal.portlet;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+
+import javax.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.display-category=category.sample",
+		"javax.portlet.display-name=A4P1 Portlet",
+		"javax.portlet.init-param.view-template=/a4p1/view_1.jsp",
+		"javax.portlet.name=com_acme_a4p1_web_internal_portlet_A4P1Portlet"
+	},
+	service = Portlet.class
+)
+public class A4P1Portlet extends MVCPortlet {
+}

--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/java/com/acme/a4p1/web/internal/portlet/action/A4P1View1MVCRenderCommand.java
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/java/com/acme/a4p1/web/internal/portlet/action/A4P1View1MVCRenderCommand.java
@@ -1,0 +1,35 @@
+package com.acme.a4p1.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+	property = {
+		"javax.portlet.name=com_acme_a4p1_web_internal_portlet_A4P1Portlet",
+		"mvc.command.name=/a4p1/view_1"
+	},
+	service = MVCRenderCommand.class
+)
+public class A4P1View1MVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+		RenderRequest renderRequest, RenderResponse renderResponse) {
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Invoke #render(RenderRequest, RenderResponse)");
+		}
+
+		return "/a4p1/view_1.jsp";
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		A4P1View1MVCRenderCommand.class);
+
+}

--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/java/com/acme/a4p1/web/internal/portlet/action/A4P1View2MVCRenderCommand.java
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/java/com/acme/a4p1/web/internal/portlet/action/A4P1View2MVCRenderCommand.java
@@ -1,0 +1,35 @@
+package com.acme.a4p1.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+	property = {
+		"javax.portlet.name=com_acme_a4p1_web_internal_portlet_A4P1Portlet",
+		"mvc.command.name=/a4p1/view_2"
+	},
+	service = MVCRenderCommand.class
+)
+public class A4P1View2MVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+		RenderRequest renderRequest, RenderResponse renderResponse) {
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Invoke #render(RenderRequest, RenderResponse)");
+		}
+
+		return "/a4p1/view_2.jsp";
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		A4P1View2MVCRenderCommand.class);
+
+}

--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/resources/META-INF/resources/a4p1/view_1.jsp
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/resources/META-INF/resources/a4p1/view_1.jsp
@@ -1,0 +1,9 @@
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<h1>View 1</h1>
+
+<portlet:renderURL var="view2URL">
+	<portlet:param name="mvcRenderCommandName" value="/a4p1/view_2" />
+</portlet:renderURL>
+
+<a href="<%= view2URL %>">Go to View 2</a>

--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/resources/META-INF/resources/a4p1/view_2.jsp
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/resources/META-INF/resources/a4p1/view_2.jsp
@@ -1,0 +1,9 @@
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<h1>View 2</h1>
+
+<portlet:renderURL var="view1URL">
+	<portlet:param name="mvcRenderCommandName" value="/a4p1/view_1" />
+</portlet:renderURL>
+
+<a href="<%= view1URL %>">Go to View 1</a>


### PR DESCRIPTION
Note, I ran into an issue with the SF. I'm going to discuss it with Hugo and the SF folks.

> Incorrect value '/a4p1/view_1' for 'mvc.command.name', see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/checks/mvc_command_name_check.markdown: /home/jhinkey/git/liferay-learn/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/mvc-render-command/resources/liferay-a4p1.zip/a4p1-web/src/main/java/com/acme/a4p1/web/internal/portlet/action/A4P1View1MVCRenderCommand.java 15 (Checkstyle:MVCCommandNameCheck)
