### PR TITLE
Changes nodeenv to 16.9.0 for tutorials using create_remote_app.sh

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -77,7 +77,7 @@ function configure_env {
 
 	if [ "${1}" == "prod" ]
 	then
-		nodeenv -p --node=15.14.0
+		nodeenv -p --node=16.9.0
 
 		activate_venv
 


### PR DESCRIPTION
The `update_example.sh` script for the Remote Apps tutorials was failing during `./build_site.sh prod`. This was due to an old node version. Updating the node version resolved the issue.